### PR TITLE
Remove symbols?

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,25 +3,6 @@
 const util = require('util');
 const ansiRegex = /\u001b\[[0-9]+m/ig;
 const colors = { enabled: true, visible: true, ansiRegex };
-const symbols = process.platform === 'win32' ? {
-  check: '√',
-  cross: '×',
-  info: 'i',
-  line: '─',
-  pointer: '>',
-  pointerSmall: '»',
-  question: '?',
-  warning: '‼'
-} : {
-  check: '✔',
-  cross: '✖',
-  info: 'ℹ',
-  line: '─',
-  pointer: '❯',
-  pointerSmall: '›',
-  question: '?',
-  warning: '⚠'
-};
 
 const styles = {
   // modifiers
@@ -131,9 +112,5 @@ for (const key of Object.keys(styles)) {
 
 colors.stripColor = colors.strip = colors.unstyle = unstyle;
 colors.styles = styles;
-colors.symbols = symbols;
-colors.ok = (...args) => {
-  return colors.green(symbols.check) + ' ' + util.format(...args);
-};
 
 module.exports = colors;


### PR DESCRIPTION
Hey~!

Is there any chance you'd consider removing the symbol definitions in this awesome module? Frankly, it's the main reason I created [`kleur`](https://github.com/lukeed/kleur), which is essentially a fork. 

Even though symbols' code is quite small, I strongly (and perhaps, stubbornly) believe they should be extracted and live as their own module. It's not always wanted. And even though it's maybe a dozen lines, the same dozen is likely repeated 20 times in a decently-sized project's dependency tree.

This would be a breaking/major change, I realize, but if you agree with me, then there's really no reason have `kleur` exist on its own.

Let me know what you think~! I have another PR incoming w/ the performance wins I unearthed while working on `kleur`.

Thanks!