### PR TITLE
Performance Gainz

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ for (const key of Object.keys(styles)) {
   decorate(styles[key]);
   Reflect.defineProperty(colors, key, {
     get() {
-      return style(this.stack ? this.stack.concat(key) : [key]);
+      return this.stack !== void 0 ? (this.stack.push(key),this) : style([key]);
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -82,13 +82,13 @@ function wrap() {
   let out = format.apply(null, arguments);
   if (!colors.enabled || out.trim().length === 0) return out;
 
-  let i=0, tmp, arr=this.stack;
-  let isMulti = !!~out.indexOf('\n');
-
-  for (; i < arr.length; i++) {
-    tmp = styles[arr[i]]; // { x1, x2, rgx }
+  let tmp, isMulti = out.includes('\n');
+  for (let i = 0; i < this.stack.length; i++) {
+    tmp = styles[this.stack[i]]; // { x1, x2, rgx }
     out = tmp.open + out.replace(tmp.closeRe, tmp.open) + tmp.close;
-    isMulti && (out = out.replace(/(\r?\n)/g, `${tmp.close}$1${tmp.open}`));
+    if (isMulti) {
+      out = out.replace(/(\r?\n)/g, `${tmp.close}$1${tmp.open}`);
+    }
   }
 
   return out;
@@ -112,7 +112,11 @@ for (let key in styles) {
   decorate(styles[key]);
   Reflect.defineProperty(colors, key, {
     get() {
-      return this.stack !== void 0 ? (this.stack.push(key),this) : style([key]);
+      if (this.stack === void 0) {
+        return style([key]);
+      }
+      this.stack.push(key);
+      return this;
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -105,10 +105,11 @@ function wrap(...args) {
 }
 
 function style(stack) {
-  const create = (...args) => wrap.call(create, ...args);
-  create.stack = stack;
-  Reflect.setPrototypeOf(create, colors);
-  return create;
+  let ctx = {};
+  let fn = wrap.bind(ctx);
+  ctx.stack = fn.stack = stack;
+  Reflect.setPrototypeOf(fn, colors);
+  return fn;
 }
 
 function decorate(style) {

--- a/index.js
+++ b/index.js
@@ -106,10 +106,9 @@ function decorate(style) {
   style.open = `\u001b[${style[0]}m`;
   style.close = `\u001b[${style[1]}m`;
   style.closeRe = new RegExp(`\\u001b\\[${style[1]}m`, 'g');
-  return style;
 }
 
-for (const key of Object.keys(styles)) {
+for (let key in styles) {
   decorate(styles[key]);
   Reflect.defineProperty(colors, key, {
     get() {

--- a/index.js
+++ b/index.js
@@ -77,8 +77,6 @@ const styles = {
   bgWhiteBright: [107, 49]
 };
 
-const isString = val => val && typeof val === 'string';
-const unstyle = val => isString(val) ? val.replace(ansiRegex, '') : val;
 const hasOpen = (input, open) => input.slice(0, open.length) === open;
 const hasClose = (input, close) => input.slice(-close.length) === close;
 const color = (str, style, hasNewline) => {
@@ -129,7 +127,10 @@ for (const key of Object.keys(styles)) {
   });
 }
 
-colors.stripColor = colors.strip = colors.unstyle = unstyle;
+colors.stripColor = colors.strip = colors.unstyle = str => {
+  return str && typeof str === 'string' ? str.replace(ansiRegex, '') : str;
+}
+
 colors.styles = styles;
 colors.symbols = symbols;
 colors.ok = (...args) => {


### PR DESCRIPTION
Hey again~

These are (most) of the optimizations I made in `kleur` that took it from 60k op/s to 90k op/s 🎉 

Some additional items of interest that were not covered in the commit messages:

* I used destructed require on `util.format` because you're already supporting Node 6+ only

* In my testing, I saw no need for `hasOpen` and `hasClose` checks. I thought I was pretty thorough but perhaps you can enlighten me

Most of the wins come from avoiding the spread operator & cutting down on the number of functions being created. The `style()` wrapper was unnecessarily invoked _per_ stack item, rather than once per stack. Also, using `[].concat` made a surprisingly bigger impact than I anticipated. 

### Before

```
# Load time
  ansi-colors: 1.126ms
  chalk: 12.708ms
  clorox: 0.900ms

# All Colors
  ansi-colors x 60,881 ops/sec ±0.60% (91 runs sampled)
  chalk x 7,048 ops/sec ±3.77% (71 runs sampled)
  clorox x 1,168 ops/sec ±3.41% (51 runs sampled)

# Stacked colors
  ansi-colors x 13,706 ops/sec ±0.37% (91 runs sampled)
  chalk x 1,683 ops/sec ±4.20% (73 runs sampled)
  clorox x 448 ops/sec ±4.10% (72 runs sampled)

# Nested colors
  ansi-colors x 28,144 ops/sec ±0.38% (95 runs sampled)
  chalk x 3,437 ops/sec ±4.36% (68 runs sampled)
  clorox x 555 ops/sec ±3.07% (44 runs sampled)
```

### After

```
# Load time
  ansi-colors: 1.037ms
  chalk: 11.317ms
  clorox: 0.869ms

# All Colors
  ansi-colors x 82,339 ops/sec ±0.39% (94 runs sampled)
  chalk x 7,237 ops/sec ±4.09% (70 runs sampled)
  clorox x 1,137 ops/sec ±3.93% (65 runs sampled)

# Stacked colors
  ansi-colors x 26,883 ops/sec ±0.16% (91 runs sampled)
  chalk x 1,733 ops/sec ±4.49% (70 runs sampled)
  clorox x 470 ops/sec ±2.21% (42 runs sampled)

# Nested colors
  ansi-colors x 40,450 ops/sec ±0.16% (95 runs sampled)
  chalk x 3,481 ops/sec ±4.58% (69 runs sampled)
  clorox x 550 ops/sec ±2.48% (42 runs sampled)
```

> All results from Node v8.9.0

---

The load time will be _slightly_ lower if/once #12 is merged; and runtime perf will increase too.

But most notably, I was not able to achieve `kleur`'s full 95k op/s simply because of the "bright" color variants. I suppose it's because the `styles` object is significantly larger, that traversal (or any reference to it) is more expensive.

Dropping the "bright" variants brings my results from 82-84k to 90-92k... in the same vein, choosing _one_ method name for clearing styles would be ideal, as it also affect object size.

Lastly, I see slightly less op/s when using `Reflect` vs `Object`. It's a very cool class that I was not aware of, but it's costing roughly 1k op/s in the "All Colors" bench.