### PR TITLE
support FORCE_COLOR

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@
 
 const colors = { enabled: true, visible: true, styles: {}, keys: {} };
 
+if ('FORCE_COLOR' in process.env) {
+  colors.enabled = process.env.FORCE_COLOR !== '0' ? true : false;
+}
+
 const ansi = codes => {
   codes.open = `\u001b[${codes[0]}m`;
   codes.close = `\u001b[${codes[1]}m`;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "mocha"
   },
   "devDependencies": {
+    "decache": "^4.4.0",
     "gulp-format-md": "^1.0.0",
     "justified": "^1.0.1",
     "mocha": "^5.2.0",

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 
 require('mocha');
 const assert = require('assert');
+const decache = require('decache');
 const colors = require('./');
 
 describe('ansi-colors', () => {
@@ -117,6 +118,30 @@ describe('enabled', () => {
     assert.equal(colors.blue('foo bar'), 'foo bar');
     assert.equal(colors.bold('foo bar'), 'foo bar');
     colors.enabled = true;
+  });
+});
+
+describe('FORCE_COLOR', () => {
+  beforeEach(() => {
+    delete process.env.FORCE_COLOR;
+    decache('./');
+  });
+
+  it('should be enabled if FORCE_COLOR is not set', () => {
+    const colors = require('./');
+    assert.equal(colors.enabled, true);
+  });
+
+  it('should be enabled if FORCE_COLOR is set to 1', () => {
+    process.env.FORCE_COLOR = '1';
+    const colors = require('./');
+    assert.equal(colors.enabled, true);
+  });
+
+  it('should be disabled if FORCE_COLOR is set to 0', () => {
+    process.env.FORCE_COLOR = '0';
+    const colors = require('./');
+    assert.equal(colors.enabled, false);
   });
 });
 


### PR DESCRIPTION
This is a feature of chalk (via [`supports-colors`](https://github.com/chalk/supports-color)) missing in ansi-colors.