### PR TITLE
chore: remove incorrect information about third-party library

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -4,11 +4,11 @@
 
 ansi-colors is _the fastest Node.js library for terminal styling_. A more performant drop-in replacement for chalk, with no dependencies.
 
-* _Blazing fast_ - Fastest terminal styling library in node.js, 10-20x faster than chalk! 
+* _Blazing fast_ - Fastest terminal styling library in node.js, 10-20x faster than chalk!
 - _Drop-in replacement_ for [chalk](https://github.com/chalk/chalk).
 - _No dependencies_ (Chalk has 7 dependencies in its tree!)
 * _Safe_ - Does not modify the `String.prototype` like [colors][].
-* Supports [nested colors](#nested-colors), **and does not have the [nested styling bug](#nested-styling-bug) that is present in [colorette][], [chalk][], and [kleur][]**.
+* Supports [nested colors](#nested-colors), **and does not have the [nested styling bug](#nested-styling-bug) that is present in [chalk][], and [kleur][]**.
 * Supports [chained colors](#chained-colors).
 * [Toggle color support](#toggle-color-support) on or off.
 
@@ -48,7 +48,7 @@ console.log(c.yellow(`foo ${c.red.bold('red')} bar ${c.cyan('cyan')} baz`));
 
 ### Nested styling bug
 
-`ansi-colors` does not have the nested styling bug found in [colorette][], [chalk][], and [kleur][].
+`ansi-colors` does not have the nested styling bug found in [chalk][], and [kleur][].
 
 ```js
 const { bold, red } = require('ansi-styles');
@@ -68,7 +68,7 @@ console.log(chalk.bold(`foo ${chalk.red.dim('bar')} baz`));
 
 (sans icons and labels)
 
-![image](https://user-images.githubusercontent.com/383994/47280326-d2ee0580-d5a3-11e8-9611-ea6010f0a253.png)
+![image](https://user-images.githubusercontent.com/56996/47354097-bfa07e80-d6f8-11e8-9229-8082743d7a4f.jpg)
 
 
 ## Toggle color support
@@ -189,4 +189,3 @@ Time it takes to load the first time `require()` is called:
   ansi-colors x 67,747 ops/sec ±0.49% (93 runs sampled)
   chalk x 4,446 ops/sec ±3.01% (82 runs sampled))
 ```
-

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ansi-colors is _the fastest Node.js library for terminal styling_. A more perfor
 * _No dependencies_ (Chalk has 7 dependencies in its tree!)
 
 * _Safe_ - Does not modify the `String.prototype` like [colors](https://github.com/Marak/colors.js).
-* Supports [nested colors](#nested-colors), **and does not have the [nested styling bug](#nested-styling-bug) that is present in [colorette](https://github.com/jorgebucaran/colorette), [chalk](https://github.com/chalk/chalk), and [kleur](https://github.com/lukeed/kleur)**.
+* Supports [nested colors](#nested-colors), **and does not have the [nested styling bug](#nested-styling-bug) that is present in [chalk](https://github.com/chalk/chalk), and [kleur](https://github.com/lukeed/kleur)**.
 * Supports [chained colors](#chained-colors).
 * [Toggle color support](#toggle-color-support) on or off.
 
@@ -61,7 +61,7 @@ console.log(c.yellow(`foo ${c.red.bold('red')} bar ${c.cyan('cyan')} baz`));
 
 ### Nested styling bug
 
-`ansi-colors` does not have the nested styling bug found in [colorette](https://github.com/jorgebucaran/colorette), [chalk](https://github.com/chalk/chalk), and [kleur](https://github.com/lukeed/kleur).
+`ansi-colors` does not have the nested styling bug found in [chalk](https://github.com/chalk/chalk), and [kleur](https://github.com/lukeed/kleur).
 
 ```js
 const { bold, red } = require('ansi-styles');
@@ -81,7 +81,7 @@ console.log(chalk.bold(`foo ${chalk.red.dim('bar')} baz`));
 
 (sans icons and labels)
 
-![image](https://user-images.githubusercontent.com/383994/47280326-d2ee0580-d5a3-11e8-9611-ea6010f0a253.png)
+![image](https://user-images.githubusercontent.com/56996/47354097-bfa07e80-d6f8-11e8-9229-8082743d7a4f.jpg)
 
 ## Toggle color support
 
@@ -244,16 +244,16 @@ You might also be interested in these projects:
 
 ### Contributors
 
-| **Commits** | **Contributor** |  
-| --- | --- |  
-| 38 | [jonschlinkert](https://github.com/jonschlinkert) |  
-| 35 | [doowb](https://github.com/doowb) |  
-| 6  | [lukeed](https://github.com/lukeed) |  
-| 2  | [Silic0nS0ldier](https://github.com/Silic0nS0ldier) |  
-| 1  | [dwieeb](https://github.com/dwieeb) |  
-| 1  | [jorgebucaran](https://github.com/jorgebucaran) |  
-| 1  | [madhavarshney](https://github.com/madhavarshney) |  
-| 1  | [chapterjason](https://github.com/chapterjason) |  
+| **Commits** | **Contributor** |
+| --- | --- |
+| 38 | [jonschlinkert](https://github.com/jonschlinkert) |
+| 35 | [doowb](https://github.com/doowb) |
+| 6  | [lukeed](https://github.com/lukeed) |
+| 2  | [Silic0nS0ldier](https://github.com/Silic0nS0ldier) |
+| 1  | [dwieeb](https://github.com/dwieeb) |
+| 1  | [jorgebucaran](https://github.com/jorgebucaran) |
+| 1  | [madhavarshney](https://github.com/madhavarshney) |
+| 1  | [chapterjason](https://github.com/chapterjason) |
 
 ### Author
 

--- a/nesting-bug.js
+++ b/nesting-bug.js
@@ -7,7 +7,7 @@ const bad = red(symbols.cross);
 console.log(bold(`foo ${cyan.dim('bar')} baz`), good, gray('(ansi-colors)'));
 
 const colorette = require('colorette');
-console.log(colorette.bold(`foo ${colorette.cyan(colorette.dim('bar'))} baz`), bad, gray('(colorette)'));
+console.log(colorette.bold(`foo ${colorette.cyan(colorette.dim('bar'))} baz`), good, gray('(colorette)'));
 
 const kleur = require('kleur');
 console.log(kleur.bold(`foo ${kleur.cyan.dim('bar')} baz`), bad, gray('(kleur)'));


### PR DESCRIPTION
## Summary

👋 Hi!  This PR removes outdated information about Colorette's bug identified in #23 and fixed in https://github.com/jorgebucaran/colorette/commit/4725f0d26044dc4dc7bf0277e9ec2d7c587d3890. 

![](https://user-images.githubusercontent.com/56996/47354097-bfa07e80-d6f8-11e8-9229-8082743d7a4f.jpg)

## Background

In ansi-colors the bug was fixed in (3bab6e74c5731eecee90fa8bfe26187e49fbedbc) by means of concatenating the close and open control sequences passed to .replace().

https://github.com/doowb/ansi-colors/blob/3bab6e74c5731eecee90fa8bfe26187e49fbedbc/index.js#L16-L18

I realized this concatenates the two strings every time the function is invoked, and since the bug is only present in nested `bold`/`dim` sequences, I fixed it by determining the search replace value at the time the function is created instead.


cc @jonschlinkert @doowb 