### PR TITLE
Fix reset code for bold style

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const create = () => {
   };
 
   define('reset', [0, 0], 'modifier');
-  define('bold', [1, 22], 'modifier');
+  define('bold', [1, 21], 'modifier');
   define('dim', [2, 22], 'modifier');
   define('italic', [3, 23], 'modifier');
   define('underline', [4, 24], 'modifier');


### PR DESCRIPTION
Fixes the reset code for `bold()`, which is incorrectly defined to be 22 (reset dim). This PR corrects it to 21.