### PR TITLE
Minor change to improve support for Parcel/SWC

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,12 @@ const identity = val => val;
 const ANSI_REGEX = /[\u001b\u009b][[\]#;?()]*(?:(?:(?:[^\W_]*;?[^\W_]*)\u0007)|(?:(?:[0-9]{1,4}(;[0-9]{0,4})*)?[~0-9=<>cf-nqrtyA-PRZ]))/g;
 
 const create = () => {
-  const colors = { enabled: true, visible: true, styles: {}, keys: {} };
-
-  if ('FORCE_COLOR' in process.env) {
-    colors.enabled = process.env.FORCE_COLOR !== '0';
-  }
+  const colors = {
+    enabled: process.env.FORCE_COLOR !== '0',
+    visible: true,
+    styles: {},
+    keys: {}
+  };
 
   const ansi = style => {
     let open = style.open = `\u001b[${style.codes[0]}m`;


### PR DESCRIPTION
Parcel is currently [unable to perform static analysis](https://github.com/parcel-bundler/parcel/issues/7904) on the `in` operator applied to `process.env`, for the purposes of bundling the module. (Parcel is a front-end to SWC, so this most likely affects SWC as well.)

Would you mind making this very minor change?

It should work exactly the same - `enabled` is `true` by default, so `FORCE_COLOR` only has an effect when set to exactly `0`.

It's a bit simpler and avoids mutations, so maybe a bit easier to read anyhow. 🙂